### PR TITLE
Publisher resources: hide lorem ipsum

### DIFF
--- a/content/resources/resource-publisher/_index.md
+++ b/content/resources/resource-publisher/_index.md
@@ -1,12 +1,26 @@
 ---
 title: Publisher Resources
-description: This section includes a Sample Policy, and any workflow template documents the Working Group develops. This section also includes a directory of publishers with name change policies, a link to those policies, and any relevant email addresses maintained by publishers for name change requests.
+description: This section includes resources for publishers who want to introduce a name change policy.
 toc: true
 authors: twg
 tags:
 categories:
 series:
-date: '2020-10-16'
+date: '2021-06-19'
 draft: false
 ---
-This section includes a Sample Policy, and any workflow template documents the Working Group develops. This section also includes a directory of publishers with name change policies, a link to those policies, and any relevant email addresses maintained by publishers for name change requests.
+This section includes resources for publishers who want to introduce a name change policy.
+
+<!--more-->
+
+## Existing Policies
+
+- We have outlined [five high-level principles for trans-inclusive name changes in academic publishing](/principles/). The Committee on Publication Ethics has [formed a working group](https://publicationethics.org/news/update-cope-guidance-regarding-author-name-changes) that will published more detailed guidance based on these high-level principles soon.
+
+- We have created a [public spreadsheet of publishers or journals with existing name change policies](https://emckclac-my.sharepoint.com/:x:/g/personal/k2032402_kcl_ac_uk/EVsKedB_EEhMireN1G8OB8IBnhb9q5v8nUigm5FG9N1Ffg) and whether they follow these high-level principles.
+
+- EDIS Group has created [a guiding checklist](https://edisgroup.org/wp-content/uploads/2021/01/Inclusive-name-change-guidance-v4.pdf) to prompt publishers on all of the steps they need to consider when creating and implementing inclusive name change policies.
+
+## Sample Policy
+
+We are currently working on a sample policy. Please contact us if you are interested in this.

--- a/content/resources/resource-publisher/_index.md
+++ b/content/resources/resource-publisher/_index.md
@@ -15,7 +15,7 @@ This section includes resources for publishers who want to introduce a name chan
 
 ## Existing Policies
 
-- We have outlined [five high-level principles for trans-inclusive name changes in academic publishing](/principles/). The Committee on Publication Ethics has [formed a working group](https://publicationethics.org/news/update-cope-guidance-regarding-author-name-changes) that will published more detailed guidance based on these high-level principles soon.
+- We have outlined [five high-level principles for trans-inclusive name changes in academic publishing](/principles/). The Committee on Publication Ethics has [formed a working group](https://publicationethics.org/news/update-cope-guidance-regarding-author-name-changes) that will publish more detailed guidance based on these high-level principles soon.
 
 - We have created a [public spreadsheet of publishers or journals with existing name change policies](https://emckclac-my.sharepoint.com/:x:/g/personal/k2032402_kcl_ac_uk/EVsKedB_EEhMireN1G8OB8IBnhb9q5v8nUigm5FG9N1Ffg) and whether they follow these high-level principles.
 

--- a/content/resources/resource-publisher/publisher-directory.md
+++ b/content/resources/resource-publisher/publisher-directory.md
@@ -7,7 +7,7 @@ tags:
 categories:
 series:
 date: '2020-10-11'
-draft: false
+draft: true
 ---
 
 A directory of publishers with name change policies, a link to those policies, and any relevant email addresses maintained by publishers for name change requests

--- a/content/resources/resource-publisher/sample-policy.md
+++ b/content/resources/resource-publisher/sample-policy.md
@@ -7,7 +7,7 @@ tags:
 categories:
 series:
 date: '2020-10-16'
-draft: false
+draft: true
 ---
 
 Sample Name Change Policy for Publishers

--- a/content/resources/resource-publisher/workflow-templates.md
+++ b/content/resources/resource-publisher/workflow-templates.md
@@ -7,7 +7,7 @@ tags:
 categories:
 series:
 date: '2020-10-16'
-draft: false
+draft: true
 ---
 
 Sample Workflow Templates for Publishers


### PR DESCRIPTION
Mark pages that only contain _lorem ipsum_ as drafts so they don’t appear on the public site.