### PR TITLE
linkfixes

### DIFF
--- a/content/resources/resource-author/_index.md
+++ b/content/resources/resource-author/_index.md
@@ -16,7 +16,7 @@ This section includes resources for authors: A list of publishers and journals w
 
 ## Existing Policies
 
-We have created [a public spreadsheet of publishers or journals with existing name change policies](https://emckclac-my.sharepoint.com/:x:/g/personal/k2032402_kcl_ac_uk/EVsKedB_EEhMireN1G8OB8IBnhb9q5v8nUigm5FG9N1Ffg). It includes links to the full policy as well as at-a-glance information on whether each policy is compatible with the [guiding principles](/principles/) described in our guest post for the Committee on Publication Ethics.
+We have created [a public spreadsheet of publishers or journals with existing name change policies](https://t.co/RW550fAaQ8). It includes links to the full policy as well as at-a-glance information on whether each policy is compatible with the [guiding principles](/principles/) described in our guest post for the Committee on Publication Ethics.
 If you are aware of any policies missing from that spreadsheet, please let us know!
 
 ## Articles & Editorials

--- a/content/resources/resource-publisher/_index.md
+++ b/content/resources/resource-publisher/_index.md
@@ -17,7 +17,7 @@ This section includes resources for publishers who want to introduce a name chan
 
 - We have outlined [five high-level principles for trans-inclusive name changes in academic publishing](/principles/). The Committee on Publication Ethics has [formed a working group](https://publicationethics.org/news/update-cope-guidance-regarding-author-name-changes) that will publish more detailed guidance based on these high-level principles soon.
 
-- We have created a [public spreadsheet of publishers or journals with existing name change policies](https://emckclac-my.sharepoint.com/:x:/g/personal/k2032402_kcl_ac_uk/EVsKedB_EEhMireN1G8OB8IBnhb9q5v8nUigm5FG9N1Ffg) and whether they follow these high-level principles.
+- We have created a [public spreadsheet of publishers or journals with existing name change policies](https://t.co/RW550fAaQ8) and whether they follow these high-level principles.
 
 - EDIS Group has created [a guiding checklist](https://edisgroup.org/wp-content/uploads/2021/01/Inclusive-name-change-guidance-v4.pdf) to prompt publishers on all of the steps they need to consider when creating and implementing inclusive name change policies.
 


### PR DESCRIPTION
use shortened link so the ":x:" doesn’t break upon deploy …